### PR TITLE
Introduce reusable workflow using labels

### DIFF
--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -3,6 +3,8 @@ description: 'Backports a PR to a target branch'
 inputs:
   pull-request:
     required: true
+  target-path:
+    type: string
   target-branch:
     required: true
   repository:
@@ -20,9 +22,13 @@ runs:
     id: run
     shell: bash
     run: |
+      if [ -n "$TARGET_PATH" ]; then
+        cd "$TARGET_PATH"
+      fi
       ${{ github.action_path }}/backport.sh "$PULL_REQUEST" "$TARGET_BRANCH" "$REPO"
     env:
       PULL_REQUEST: ${{ inputs.pull-request }}
+      TARGET_PATH: ${{ inputs.target-path }}
       TARGET_BRANCH: ${{ inputs.target-branch }}
       REPO: ${{ inputs.repository }}
       IS_DRAFT: ${{ inputs.is-draft }}

--- a/.github/actions/backport/action.yml
+++ b/.github/actions/backport/action.yml
@@ -1,0 +1,28 @@
+name: 'Backport PR'
+description: 'Backports a PR to a target branch'
+inputs:
+  pull-request:
+    required: true
+  target-branch:
+    required: true
+  repository:
+    required: true
+  is-draft:
+    default: false
+    type: boolean
+outputs:
+  pr-url:
+    value: ${{ steps.run.outputs.pr-url }}
+runs:
+  using: "composite"
+  steps:
+  - name: Run it
+    id: run
+    shell: bash
+    run: |
+      ${{ github.action_path }}/backport.sh "$PULL_REQUEST" "$TARGET_BRANCH" "$REPO"
+    env:
+      PULL_REQUEST: ${{ inputs.pull-request }}
+      TARGET_BRANCH: ${{ inputs.target-branch }}
+      REPO: ${{ inputs.repository }}
+      IS_DRAFT: ${{ inputs.is-draft }}

--- a/.github/actions/backport/backport.sh
+++ b/.github/actions/backport/backport.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+
+set -e
+
+PULL_REQUEST=$1
+TARGET_BRANCH=$2
+REPO=$3
+
+IS_DRAFT=${IS_DRAFT:-false}
+if [ "$IS_DRAFT" = "true" ]; then
+	DRAFT_FLAG="--draft"
+fi
+
+if [ -z "$PULL_REQUEST" ] || [ -z "$TARGET_BRANCH" ] || [ -z "$REPO" ]; then
+	echo "Usage: $0 <PR number> <target branch> <owner/repo>" 1>&2
+	exit 1
+fi
+
+GITHUB_TRIGGERING_ACTOR=${GITHUB_TRIGGERING_ACTOR:-}
+
+repo_name=$(echo "$REPO" | cut -d/ -f2)
+repo_owner=$(echo "$REPO" | cut -d/ -f1)
+
+target_slug=$(echo "$TARGET_BRANCH" | sed "s|/|-|")
+branch_name="backport-$PULL_REQUEST-$target_slug-$$"
+
+pr_link=https://github.com/$REPO/pull/$PULL_REQUEST
+pr_number=$PULL_REQUEST
+
+# Separate calls because otherwise it was creating trouble.. can probably be fixed
+old_title=$(gh pr view "$pr_number" --json title --jq '.title')
+old_body=$(gh pr view "$pr_number" --json body --jq '.body')
+
+git checkout -b "$branch_name" "origin/$TARGET_BRANCH"
+
+committed_something=""
+
+failed_commit=""
+skipped_commits=""
+
+for commit in $(GH_PAGER=  gh pr view "$pr_number" --json commits --jq '.commits[].oid'); do
+	if [ -n "$failed_commit" ]; then
+		skipped_commits="$skipped_commits
+$commit"
+		continue
+	fi
+	# Those commits might be orphaned so we attempt to fetch them
+	git fetch origin "$commit:refs/remotes/origin/orphaned-commit"
+
+	if git cherry-pick --allow-empty "$commit"; then
+		committed_something="true"
+	else
+		echo "Cherry-pick failed, skipping" 1>&2
+		git cherry-pick --abort
+		failed_commit="$commit"
+	fi
+done
+
+if [ -z "$committed_something" ]; then
+	# Github won't allow us to create a PR without any changes so we're making an empty commit here
+	git commit --allow-empty -m "Please amend this commit"
+fi
+
+git push -u origin "$branch_name"
+
+generated_by=""
+if [ -n "$GITHUB_TRIGGERING_ACTOR" ]; then
+    generated_by=$(cat <<EOF
+The workflow was triggered by @$GITHUB_TRIGGERING_ACTOR.
+EOF
+)
+fi
+
+failed=""
+if [ -n "$failed_commit" ]; then
+	failed=$(cat <<EOF
+Cherry-picking failed, here are the list of commits that are missing:
+
+\`\`\`
+$failed_commit
+$skipped_commits
+\`\`\`
+EOF
+)
+fi
+
+title=$(echo "[$TARGET_BRANCH] $old_title")
+body=$(cat <<EOF
+**Backport**
+
+Backport of $pr_link
+
+You can make changes to this PR with the following command:
+
+\`\`\`
+git clone https://github.com/$REPO
+cd $repo_name
+git switch $branch_name
+\`\`\`
+
+$failed
+
+$generated_by
+
+---
+
+$old_body
+EOF
+)
+
+PR_URL=$(gh pr create \
+  --title "$title" \
+  --body "$body" \
+  --repo "$REPO" \
+  --head "$(echo $REPO | cut -d/ -f1):$branch_name" \
+  --base "$TARGET_BRANCH" \
+  $DRAFT_FLAG)
+echo "Created PR at $PR_URL"
+echo "pr-url=$PR_URL" >> $GITHUB_OUTPUT

--- a/.github/workflows/cherry-pick-from-labels.yaml
+++ b/.github/workflows/cherry-pick-from-labels.yaml
@@ -19,14 +19,6 @@ on:
         description: ""
         required: true
         type: string
-      git-user-email:
-        description: ""
-        required: true
-        type: string
-      git-user-name:
-        description: ""
-        required: true
-        type: string
       skip-membership-check:
         default: false
         type: boolean
@@ -84,11 +76,8 @@ jobs:
 
       - if: ${{ steps.detect.outputs.target-branch != '' }}
         run: |
-          git config --global user.email "$EMAIL"
-          git config --global user.name "$NAME"
-        env:
-          EMAIL: ${{ inputs.git-user-email }}
-          NAME: ${{ inputs.git-user-name }}
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - if: ${{ steps.detect.outputs.target-branch != '' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5

--- a/.github/workflows/cherry-pick-from-labels.yaml
+++ b/.github/workflows/cherry-pick-from-labels.yaml
@@ -1,0 +1,117 @@
+name: Cherry-pick a PR using labels
+
+on:
+  workflow_call:
+    inputs:
+      label-added:
+        description: "Create the labels in this repository"
+        required: true
+        type: string
+      all-labels-json:
+        description: "List of all labels for the PR"
+        required: true
+        type: string
+      pr-number:
+        description: ""
+        required: true
+        type: string
+      git-user-email:
+        description: ""
+        required: true
+        type: string
+      git-user-name:
+        description: ""
+        required: true
+        type: string
+      skip-membership-check:
+        default: false
+        type: boolean
+    secrets:
+      token:
+        required: true
+
+jobs:
+  cherry-pick-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check org membership
+        id: membership
+        env:
+          GH_TOKEN: ${{ secrets.token }}
+          SKIP: ${{ inputs.skip-membership-check }}
+        run: |
+          if [ "$SKIP" = "true" ]; then
+            echo "is_member=true" >> $GITHUB_OUTPUT
+          else
+            if gh api orgs/${GITHUB_REPOSITORY_OWNER}/members --paginate | jq -e --arg GITHUB_ACTOR "$GITHUB_ACTOR" '.[] | select(.login == $GITHUB_ACTOR)' > /dev/null; then
+                echo "${GITHUB_ACTOR} is a member"
+                echo "is_member=true" >> $GITHUB_OUTPUT
+            else
+                echo "${GITHUB_ACTOR} is not a member" >> $GITHUB_STEP_SUMMARY
+                echo "is_member=false" >> $GITHUB_OUTPUT
+            fi
+          fi
+
+      - if: ${{ steps.membership.outputs.is_member == 'true' }}
+        id: detect
+        run: |
+          has_label() {
+            labels=$(printf '%s' "$LABELS" | jq -r '.[]')
+            for l in $labels; do
+              if [ "$l" = "$1" ]; then
+                return 0
+              fi
+            done
+            return 1
+          }
+
+          target="$(echo "$CHERRY_PICK_LABEL" | sed 's|cherry-pick/||')"
+          if has_label "cherry-pick-done/$target"; then
+            echo "Skipping $label ($target) because already cherry-picked"
+            echo "target-branch=" >> $GITHUB_OUTPUT
+            return 0
+          fi
+
+          echo "Need to create cherry-pick for $label ($target)"
+          echo "target-branch=$target" >> $GITHUB_OUTPUT
+        env:
+          CHERRY_PICK_LABEL: ${{ inputs.label-added }}
+          LABELS: ${{ inputs.all-labels-json }}
+
+      - if: ${{ steps.detect.outputs.target-branch != '' }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          token: ${{ secrets.token }}
+          persist-credentials: true
+          fetch-depth: 0
+
+      - if: ${{ steps.detect.outputs.target-branch != '' }}
+        run: |
+          git config --global user.email "$EMAIL"
+          git config --global user.name "$NAME"
+        env:
+          EMAIL: ${{ inputs.git-user-email }}
+          NAME: ${{ inputs.git-user-name }}
+
+      - if: ${{ steps.detect.outputs.target-branch != '' }}
+        uses: ./.github/actions/backport
+        id: backport
+        with:
+          pull-request: ${{ inputs.pr-number }}
+          target-branch: ${{ steps.detect.outputs.target-branch }}
+          repository: ${{ github.repository }}
+          is-draft: false
+        env:
+          GH_TOKEN: ${{ secrets.token }}
+
+      - if: ${{ steps.detect.outputs.target-branch != '' }}
+        run: |
+          gh pr edit $PR_NUMBER -R "$REPO" --add-label "cherry-pick-done/$TARGET"
+          gh pr comment $PR_NUMBER -R "$REPO" --body "Cherry-pick requested from @$GITHUB_ACTOR. Created the following cherry-pick PR: $BACKPORT_PR_URL. See run for more details at: $RUN_URL"
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BACKPORT_PR_URL: ${{ steps.backport.outputs.pr-url }}
+          TARGET: ${{ steps.detect.outputs.target-branch }}
+          GH_TOKEN: ${{ secrets.token }}
+          PR_NUMBER: ${{ inputs.pr-number }}
+          REPO: ${{ github.repository }}

--- a/.github/workflows/cherry-pick-from-labels.yaml
+++ b/.github/workflows/cherry-pick-from-labels.yaml
@@ -3,6 +3,10 @@ name: Cherry-pick a PR using labels
 on:
   workflow_call:
     inputs:
+      workflow-ref:
+        description: "The version of this repo to use the composite action. Should match the version of the call to this reusable workflow."
+        required: true
+        type: string
       label-added:
         description: "Create the labels in this repository"
         required: true
@@ -79,13 +83,6 @@ jobs:
           LABELS: ${{ inputs.all-labels-json }}
 
       - if: ${{ steps.detect.outputs.target-branch != '' }}
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-        with:
-          token: ${{ secrets.token }}
-          persist-credentials: true
-          fetch-depth: 0
-
-      - if: ${{ steps.detect.outputs.target-branch != '' }}
         run: |
           git config --global user.email "$EMAIL"
           git config --global user.name "$NAME"
@@ -94,18 +91,35 @@ jobs:
           NAME: ${{ inputs.git-user-name }}
 
       - if: ${{ steps.detect.outputs.target-branch != '' }}
-        uses: ./.github/actions/backport
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          token: ${{ secrets.token }}
+          persist-credentials: true
+          fetch-depth: 0
+          path: target
+
+      - if: ${{ steps.detect.outputs.target-branch != '' }}
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          repository: "tomleb/rancher-cherry-pick-action"
+          ref: "${{ inputs.workflow-ref }}"
+          path: cherry-pick-action
+
+      - if: ${{ steps.detect.outputs.target-branch != '' }}
+        uses: ./cherry-pick-action/.github/actions/backport
         id: backport
         with:
           pull-request: ${{ inputs.pr-number }}
           target-branch: ${{ steps.detect.outputs.target-branch }}
           repository: ${{ github.repository }}
           is-draft: false
+          target-path: target
         env:
           GH_TOKEN: ${{ secrets.token }}
 
       - if: ${{ steps.detect.outputs.target-branch != '' }}
         run: |
+          cd target
           gh pr edit $PR_NUMBER -R "$REPO" --add-label "cherry-pick-done/$TARGET"
           gh pr comment $PR_NUMBER -R "$REPO" --body "Cherry-pick requested from @$GITHUB_ACTOR. Created the following cherry-pick PR: $BACKPORT_PR_URL. See run for more details at: $RUN_URL"
         env:

--- a/.github/workflows/cherry-pick-from-labels.yaml
+++ b/.github/workflows/cherry-pick-from-labels.yaml
@@ -87,6 +87,11 @@ jobs:
           fetch-depth: 0
           path: target
 
+      # Github Actions don't support running composite actions from a reusable
+      # workflow in the same repository.
+      # The workaround is to clone the repository and run it. This does require
+      # the ref to be set properly by the caller (which really sucks)
+      # https://github.com/orgs/community/discussions/123261
       - if: ${{ steps.detect.outputs.target-branch != '' }}
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:

--- a/.github/workflows/generate-cherry-pick-labels.yaml
+++ b/.github/workflows/generate-cherry-pick-labels.yaml
@@ -38,7 +38,7 @@ jobs:
               --force
             gh -R "$REPO" label create cherry-pick-done/$branch \
               --description "Mark PR as already cherry-picked for branch $branch" \
-              --color "$DONE_COLOR" \
+              --color "$COLOR_DONE" \
               --force
           done
         env:

--- a/.github/workflows/generate-cherry-pick-labels.yaml
+++ b/.github/workflows/generate-cherry-pick-labels.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          branches=$(gh api repos/$REPO/branches | jq -r '.[].name')
+          branches=$(gh api --paginate repos/$REPO/branches | jq -r '.[].name')
 
           for branch in $branches; do
             if ! echo "$branch" | grep -Eq "$REGEX"; then

--- a/.github/workflows/generate-cherry-pick-labels.yaml
+++ b/.github/workflows/generate-cherry-pick-labels.yaml
@@ -1,0 +1,49 @@
+name: Generate cherry-pick labels
+
+on:
+  workflow_call:
+    inputs:
+      branch-filter-regex:
+        description: "Regex to filter which branches need cherry-pick labels (eg: main|release/.*)"
+        required: true
+        type: string
+      color:
+        description: "Color of the cherry-pick/* labels (eg: FF00FF)"
+        default: "38B395"
+        type: string
+      color-done:
+        description: "Color of the cherry-pick-done/* labels (eg: FF00FF)"
+        default: "E99695"
+        type: string
+    secrets:
+      token:
+        required: true
+
+jobs:
+  generate-cherry-pick-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          branches=$(gh api repos/$REPO/branches | jq -r '.[].name')
+
+          for branch in $branches; do
+            if ! echo "$branch" | grep -Eq "$REGEX"; then
+              continue
+            fi
+
+            echo "Creating or updating cherry-pick labels for branch $branch"
+            gh -R "$REPO" label create cherry-pick/$branch \
+              --description "Create cherry-pick PR for branch $branch" \
+              --color "$COLOR" \
+              --force
+            gh -R "$REPO" label create cherry-pick-done/$branch \
+              --description "Mark PR as already cherry-picked for branch $branch" \
+              --color "$DONE_COLOR" \
+              --force
+          done
+        env:
+          REPO: ${{ github.repository }}
+          COLOR: ${{ inputs.color }}
+          COLOR_DONE: ${{ inputs.color-done }}
+          GH_TOKEN: ${{ secrets.token }}
+          REGEX: ${{ inputs.branch-filter-regex }}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,69 @@
 # Cherry-pick GHA
+
+# How to
+
+## Using labels
+
+In your repository, add the following two workflows.
+
+1. Add the workflow that will trigger on label on merged pull requests in `.github/workflows/backport-label.yaml`
+
+```yaml
+name: Backport label
+
+on:
+  pull_request:
+    types: [labeled]
+    branches:
+    - main
+    - 'release/**'
+
+jobs:
+  backport-label:
+    permissions:
+      # Necessary to add cherry-pick-done/* label
+      pull-requests: write
+      # Necessary to create the PR
+      #
+      # NOTE: We'll want to switch to an app token once we have one.
+      # Reason: GHA is designed to not trigger other workflows when creating a PR
+      # within a workflow run using the workflow run token.
+      #
+      # Temporary workaround is to close/re-open the PR in the UI. This will trigger
+      # the pull_request event.
+      contents: write
+
+    # For now, only run if the PR is merged
+    if: github.event.pull_request.merged == true && startsWith(github.event.label.name, 'cherry-pick/')
+    uses: rancher/cherry-pick-action/.github/workflows/cherry-pick-from-labels.yaml@main
+    with:
+      # Must match the version used for the reusable workflow above (eg: @<ref>)
+      workflow-ref: main
+      label-added: ${{ github.event.label.name }}
+      all-labels-json: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+      pr-number: ${{ github.event.pull_request.number }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+2. Add the workflow that will automatically generate labels for your release
+   branches at `.github/workflows/generate-cherry-pick-labels.yaml`
+
+```yaml
+name: Auto-generate cherry-pick labels
+
+on:
+  workflow_dispatch:
+  create:
+
+jobs:
+  generate-cherry-pick-labels:
+    permissions:
+      # Necessary to create/edit labels
+      issues: write
+    uses: rancher/cherry-pick-action/.github/workflows/generate-cherry-pick-labels.yaml@main
+    with:
+      branch-filter-regex: "^main|release/.*"
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+```


### PR DESCRIPTION
# Issue https://github.com/rancher/rancher/issues/52006

This introduces reusable workflows to automatically create backports using labels.

The README.md file already contains an example on how to use it in other repositories. Here's an example PR this opens: https://github.com/tomleb/rancher-steve/pull/49.

**Caveats**

One very annoying thing about github actions is how poorly integrated reusable workflows and composite actions are together. I was thinking: use reusable workflow to trigger the cherry-pick, so one for label trigger, one for manual trigger (if needed), one for comment trigger, etc. And all these reusable workflow would reuse the composite action.

It works, but it's not pretty: we need to have the version of the `rancher/cherry-pick-action` repo in two places..

```yaml
   # <ref> here once for the version of the reusable workflow
    uses: rancher/cherry-pick-action/.github/workflows/cherry-pick-from-labels.yaml@<ref>
    with:
      # <ref> a second time here, because we must clone the repo at the same ref
      workflow-ref: <ref>
      ...
```

# TL;DR

Automate backport PRs with labels, here's the GIF:

![output](https://github.com/user-attachments/assets/b51559b7-06f8-444f-bd5c-ba892d20ec82)


# Solution

Here's what is introduced in this PR:
- A "composite" action that can be reused, self-contained, it does ALL the work above.
- Trigger this action using labels on the PR (`cherry-pick/<target-branch>`). More on this below.
- Another GHA to automatically create the labels because we definitely don't want to maintain this manually.

## Composite action

The action is currently using bash, will be migrated to Go eventually. (@alexander-demicev )

Some features this currently have:
- Gracefully handles cherry-pick errors. The PR is still created, and it's easy to handle conflicts (commits failed to cherry-pick are added to the created PR).
- Copies the body / title of the original PR
- Allow creating draft PRs (not used yet)
Some features missing:
- Doesn't yet assign the reviewers from original PR to the new one

## Triggering based on label

Essentially, **when a PR is already merged**, you can create a backport PR by adding a label to the original PR of the form `cherry-pick/<target-branch>`. For example, if you want to backport a PR to `release/v0.6`, you would add the label `cherry-pick/release/v0.6`.

Once the backport PR is opened, a new label `cherry-pick-done/<target-branch>` is added to the original PR to prevent re-running the cherry-pick action. (If needed, you can remove that one and the cherry-pick one and re-add to re-trigger the workflow if needed).

A comment is create in the original PR to let you know that a backport PR has been created. See an example here: https://github.com/tomleb/rancher-steve/pull/39#issuecomment-3334869122.

Limitations:
- The PR has to already be merged. If the label is added before the PR is merged, then on merge nothing will happen. Workaround is: remove the label and add it again. We can probably get rid of this limitation eventually, needs more exploration on my side, but for now that's what I'm settling with.

Features:
- Does a membership check to ensure only rancher member can trigger those workflows. (Taken from UI's backport script) 

## Auto creating labels

Since the solution relies on labels, those labels need to exists prior. We simply create them automatically (either via a manual workflow run or whenever a new branch is created). In case of steve, we want to match on:
- `main`
- `release/*`

This means we'll generate the following labels:
- `cherry-pick/main`
- `cherry-pick-done/main`
- `cherry-pick/release/v0.6`
- `cherry-pick-done/release/v0.6` 
- `cherry-pick/release/v0.5`
- `cherry-pick-done/release/v0.5`
etc

# Additional context
Note: There's multiple ways to trigger backport PRs, I've experimented a bit:
- Using comments: https://github.com/tomleb/rancher-steve/blob/test-backport-pr/.github/workflows/backport-comment.yaml (eg: `/backport <target branch>`)
- Using labels (used in this PR)
- Manually: https://github.com/tomleb/rancher-steve/blob/test-backport-pr/.github/workflows/backport.yaml (more configurable behavior)

# Usage

Here's how you actually use it in another repository.

In your repository, add the following two workflows.

1. Add the workflow that will trigger on label on merged pull requests in `.github/workflows/backport-label.yaml`

```yaml
name: Backport label

on:
  pull_request:
    types: [labeled]
    branches:
    - main
    - 'release/**'

jobs:
  backport-label:
    permissions:
      # Necessary to add cherry-pick-done/* label
      pull-requests: write
      # Necessary to create the PR
      #
      # NOTE: We'll want to switch to an app token once we have one.
      # Reason: GHA is designed to not trigger other workflows when creating a PR
      # within a workflow run using the workflow run token.
      #
      # Temporary workaround is to close/re-open the PR in the UI. This will trigger
      # the pull_request event.
      contents: write

    # For now, only run if the PR is merged
    if: github.event.pull_request.merged == true && startsWith(github.event.label.name, 'cherry-pick/')
    uses: rancher/cherry-pick-action/.github/workflows/cherry-pick-from-labels.yaml@main
    with:
      # Must match the version used for the reusable workflow above (eg: @<ref>)
      workflow-ref: main
      label-added: ${{ github.event.label.name }}
      all-labels-json: ${{ toJSON(github.event.pull_request.labels.*.name) }}
      pr-number: ${{ github.event.pull_request.number }}
    secrets:
      token: ${{ secrets.GITHUB_TOKEN }}
```

2. Add the workflow that will automatically generate labels for your release
   branches at `.github/workflows/generate-cherry-pick-labels.yaml`

```yaml
name: Auto-generate cherry-pick labels

on:
  workflow_dispatch:
  create:

jobs:
  generate-cherry-pick-labels:
    permissions:
      # Necessary to create/edit labels
      issues: write
    uses: rancher/cherry-pick-action/.github/workflows/generate-cherry-pick-labels.yaml@main
    with:
      branch-filter-regex: "^main|release/.*"
    secrets:
      token: ${{ secrets.GITHUB_TOKEN }}
```